### PR TITLE
Integrate webhook server to api server

### DIFF
--- a/cmd/apiserver.go
+++ b/cmd/apiserver.go
@@ -22,14 +22,15 @@ func NewAPIServer(ctx CommandContext) *cobra.Command {
 }
 
 type APIServerConfig struct {
-	Kubeconfig      string
-	Name            string
-	Version         string
-	Namespace       string
-	Threadiness     int
-	HTTPListenPort  int
-	HTTPSListenPort int
-	debugConfig     debug.Config
+	Kubeconfig             string
+	Name                   string
+	Version                string
+	Namespace              string
+	Threadiness            int
+	HTTPListenPort         int
+	HTTPSListenPort        int
+	WebhookHTTPSListenPort int
+	debugConfig            debug.Config
 
 	cmdCtx CommandContext
 }
@@ -39,11 +40,12 @@ func (a *APIServerConfig) Run(cmd *cobra.Command, _ []string) error {
 
 	ctx := cmd.Context()
 	cfg := server.Options{
-		Context:         ctx,
-		KubeConfig:      a.cmdCtx.OneBlock.Kubeconfig,
-		HTTPListenPort:  a.HTTPListenPort,
-		HTTPSListenPort: a.HTTPSListenPort,
-		Namespace:       a.Namespace,
+		Context:                ctx,
+		KubeConfig:             a.cmdCtx.OneBlock.Kubeconfig,
+		HTTPListenPort:         a.HTTPListenPort,
+		HTTPSListenPort:        a.HTTPSListenPort,
+		WebhookHTTPSListenPort: a.WebhookHTTPSListenPort,
+		Namespace:              a.Namespace,
 	}
 	ob, err := server.New(cfg)
 	if err != nil {
@@ -61,4 +63,5 @@ func (a *APIServerConfig) init(apiCmd *cobra.Command) {
 	f.IntVar(&a.Threadiness, "threadiness", 5, "controller threads")
 	f.IntVar(&a.HTTPListenPort, "http_port", 8080, "HTTP listen port")
 	f.IntVar(&a.HTTPSListenPort, "https_port", 8443, "HTTPS listen port")
+	f.IntVar(&a.WebhookHTTPSListenPort, "webhook_https_port", 8444, "webhook HTTPS listen port")
 }

--- a/deploy/charts/oneblock/templates/service.yaml
+++ b/deploy/charts/oneblock/templates/service.yaml
@@ -13,3 +13,18 @@ spec:
       name: https
   selector:
     {{- include "oneblock.selectorLabels" . | nindent 4 }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: oneblock-webhook
+  labels:
+    {{- include "oneblock.labels" . | nindent 4 }}
+spec:
+  ports:
+    - port: 443
+      targetPort: {{ .Values.service.webhookTargetPort }} # keep the port same as what's specified in the apiserver cmd.
+      protocol: TCP
+      name: webhook-https
+  selector:
+    {{- include "oneblock.selectorLabels" . | nindent 4 }}

--- a/deploy/charts/oneblock/values.yaml
+++ b/deploy/charts/oneblock/values.yaml
@@ -40,7 +40,7 @@ service:
   ## Specify the port of HTTPs endpoint.
   ## defaults to "8443".
   httpsPort: 8443
-
+  webhookTargetPort: 8444
   ## Specify the port of HTTP endpoint,
   ## this port will be closed if set to 0.
   ## defaults to "0".

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/oneblock-ai/apiserver/v2 v2.0.0-20231120080835-6d0178f2cdd8
 	github.com/oneblock-ai/dynamiclistener/v2 v2.0.0-20231114071240-8bd0d400c27d
 	github.com/oneblock-ai/steve/v2 v2.0.0-20231208071956-a554480398db
+	github.com/oneblock-ai/webhook v0.0.0-20231218135224-857f785b7789
 	github.com/onsi/ginkgo/v2 v2.11.0
 	github.com/onsi/gomega v1.27.10
 	github.com/pkg/errors v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -288,6 +288,8 @@ github.com/oneblock-ai/dynamiclistener/v2 v2.0.0-20231114071240-8bd0d400c27d h1:
 github.com/oneblock-ai/dynamiclistener/v2 v2.0.0-20231114071240-8bd0d400c27d/go.mod h1:yKX/KgxhhidYj3vQjIY7UEvRJk7H1eY2D9ox90gj2j4=
 github.com/oneblock-ai/steve/v2 v2.0.0-20231208071956-a554480398db h1:xl6Zxm1HTyEcKG1NNg0x02fI85hoLgAj+aF0V2vqhPc=
 github.com/oneblock-ai/steve/v2 v2.0.0-20231208071956-a554480398db/go.mod h1:zgkg0HZZifkTrIomVh5PtGPdaDLsUNDrhTSR6l64J20=
+github.com/oneblock-ai/webhook v0.0.0-20231218135224-857f785b7789 h1:h1157UQgwY7Hj564RJx4rBeCKCVn3tANmdnl0crl1D0=
+github.com/oneblock-ai/webhook v0.0.0-20231218135224-857f785b7789/go.mod h1:To6L+2tsy7Hq6UX0GiIyZoNNtl/afq26EfzKLtTstjc=
 github.com/onsi/ginkgo v0.0.0-20170829012221-11459a886d9c/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.11.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -2,39 +2,50 @@ package server
 
 import (
 	"context"
+	"fmt"
 
 	dlserver "github.com/oneblock-ai/dynamiclistener/v2/server"
 	"github.com/oneblock-ai/steve/v2/pkg/server"
+	wc "github.com/oneblock-ai/webhook/pkg/config"
+	ws "github.com/oneblock-ai/webhook/pkg/server"
 	"github.com/rancher/wrangler/v2/pkg/ratelimit"
 	"k8s.io/client-go/rest"
 
 	oneblockAuth "github.com/oneblock-ai/oneblock/pkg/api/auth"
 	"github.com/oneblock-ai/oneblock/pkg/controller"
 	"github.com/oneblock-ai/oneblock/pkg/server/config"
+	"github.com/oneblock-ai/oneblock/pkg/webhook"
+)
+
+const (
+	webhookName = "oneblock-webhook"
 )
 
 // Server defines the api server types
 type Server struct {
-	ctx             context.Context
-	kubeconfig      string
-	httpListenPort  int
-	httpsListenPort int
-	threadiness     int
-	namespace       string
+	ctx                    context.Context
+	kubeconfig             string
+	httpListenPort         int
+	httpsListenPort        int
+	webhookHTTPSListenPort int
+	threadiness            int
+	namespace              string
 
-	mgmt        *config.Management
-	steveServer *server.Server
-	restConfig  *rest.Config
+	mgmt          *config.Management
+	steveServer   *server.Server
+	webhookServer *ws.WebhookServer
+	restConfig    *rest.Config
 }
 
 // Options define the api server options
 type Options struct {
-	Context         context.Context
-	KubeConfig      string
-	HTTPListenPort  int
-	HTTPSListenPort int
-	Threadiness     int
-	Namespace       string
+	Context                context.Context
+	KubeConfig             string
+	HTTPListenPort         int
+	HTTPSListenPort        int
+	WebhookHTTPSListenPort int
+	Threadiness            int
+	Namespace              string
 }
 
 func (s *Server) setDefaults(cfg *rest.Config) (*server.Options, error) {
@@ -61,12 +72,13 @@ func (s *Server) setDefaults(cfg *rest.Config) (*server.Options, error) {
 func New(opts Options) (*Server, error) {
 	var err error
 	s := &Server{
-		ctx:             opts.Context,
-		kubeconfig:      opts.KubeConfig,
-		httpListenPort:  opts.HTTPListenPort,
-		httpsListenPort: opts.HTTPSListenPort,
-		namespace:       opts.Namespace,
-		threadiness:     opts.Threadiness,
+		ctx:                    opts.Context,
+		kubeconfig:             opts.KubeConfig,
+		httpListenPort:         opts.HTTPListenPort,
+		httpsListenPort:        opts.HTTPSListenPort,
+		webhookHTTPSListenPort: opts.WebhookHTTPSListenPort,
+		namespace:              opts.Namespace,
+		threadiness:            opts.Threadiness,
 	}
 
 	clientConfig, err := GetConfig(s.kubeconfig)
@@ -91,14 +103,32 @@ func New(opts Options) (*Server, error) {
 	if err != nil {
 		return nil, err
 	}
+	// set up a new webhook server
+	s.webhookServer = ws.NewWebhookServer(opts.Context, restConfig, webhookName, &wc.Options{
+		Namespace:       opts.Namespace,
+		Threadiness:     opts.Threadiness,
+		HTTPSListenPort: opts.WebhookHTTPSListenPort,
+	})
 
-	if err := controller.Register(s.ctx, s.mgmt, s.threadiness); err != nil {
-		return s, err
+	if err := webhook.Register(opts.Context, restConfig, opts.Threadiness, s.webhookServer); err != nil {
+		return nil, err
+	}
+
+	if err := controller.Register(opts.Context, s.mgmt, opts.Threadiness); err != nil {
+		return nil, err
 	}
 
 	return s, nil
 }
 
 func (s *Server) ListenAndServe(opts *dlserver.ListenOpts) error {
+	var err error
+	go func() {
+		err = s.webhookServer.Start()
+	}()
+	if err != nil {
+		return fmt.Errorf("start webhook server failed: %w", err)
+	}
+
 	return s.steveServer.ListenAndServe(s.ctx, s.httpsListenPort, s.httpListenPort, opts)
 }

--- a/pkg/webhook/config/config.go
+++ b/pkg/webhook/config/config.go
@@ -1,0 +1,38 @@
+package config
+
+import (
+	"context"
+
+	"github.com/rancher/wrangler/v2/pkg/start"
+	"k8s.io/client-go/rest"
+
+	obmgmtv1 "github.com/oneblock-ai/oneblock/pkg/generated/controllers/management.oneblock.ai"
+)
+
+type Management struct {
+	ctx        context.Context
+	RestConfig *rest.Config
+
+	OneBlockMgmtFactory *obmgmtv1.Factory
+	starters            []start.Starter
+}
+
+func SetupManagement(ctx context.Context, restConfig *rest.Config) (*Management, error) {
+	mgmt := &Management{
+		ctx:        ctx,
+		RestConfig: restConfig,
+	}
+
+	var err error
+	mgmt.OneBlockMgmtFactory, err = obmgmtv1.NewFactoryFromConfig(restConfig)
+	if err != nil {
+		return nil, err
+	}
+	mgmt.starters = append(mgmt.starters, mgmt.OneBlockMgmtFactory)
+
+	return mgmt, nil
+}
+
+func (m *Management) Start(threadiness int) error {
+	return start.All(m.ctx, threadiness, m.starters...)
+}

--- a/pkg/webhook/register.go
+++ b/pkg/webhook/register.go
@@ -1,0 +1,52 @@
+package webhook
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/oneblock-ai/webhook/pkg/server"
+	"github.com/oneblock-ai/webhook/pkg/server/admission"
+	"k8s.io/client-go/rest"
+
+	"github.com/oneblock-ai/oneblock/pkg/webhook/config"
+	"github.com/oneblock-ai/oneblock/pkg/webhook/user"
+)
+
+func register(mgmt *config.Management) (validators []admission.Validator, mutators []admission.Mutator) {
+	validators = []admission.Validator{
+		user.NewValidator(mgmt),
+	}
+
+	mutators = []admission.Mutator{
+		user.NewMutator(),
+	}
+
+	return
+}
+
+func Register(ctx context.Context, restConfig *rest.Config, threadiness int, ws *server.WebhookServer) error {
+	// Separated factories are needed for the webhook register.
+	// Controllers are running in active/standby mode. If the webhook register and controllers are use the same factories,
+	// when the standby pod is upgraded to be active, it will be unable to add handlers and indexers to the controllers
+	// because the factories are already started.
+	mgmt, err := config.SetupManagement(ctx, restConfig)
+	if err != nil {
+		return fmt.Errorf("setup management failed: %w", err)
+	}
+
+	validators, mutators := register(mgmt)
+
+	if err := ws.RegisterValidators(validators...); err != nil {
+		return fmt.Errorf("register validators failed: %w", err)
+	}
+
+	if err := ws.RegisterMutators(mutators...); err != nil {
+		return fmt.Errorf("register mutators failed: %w", err)
+	}
+
+	if err := mgmt.Start(threadiness); err != nil {
+		return fmt.Errorf("start management failed: %w", err)
+	}
+
+	return nil
+}

--- a/pkg/webhook/user/mutator.go
+++ b/pkg/webhook/user/mutator.go
@@ -1,0 +1,50 @@
+package user
+
+import (
+	"github.com/oneblock-ai/webhook/pkg/server/admission"
+	"github.com/sirupsen/logrus"
+	admissionregv1 "k8s.io/api/admissionregistration/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	managementv1 "github.com/oneblock-ai/oneblock/pkg/apis/management.oneblock.ai/v1"
+)
+
+type mutator struct {
+	admission.DefaultMutator
+}
+
+var _ admission.Mutator = &mutator{}
+
+func NewMutator() admission.Mutator {
+	return &mutator{}
+}
+
+func (m *mutator) Create(_ *admission.Request, newObj runtime.Object) (admission.Patch, error) {
+	user := newObj.(*managementv1.User)
+	logrus.Infof("[webhook mutating]user %s is created", user.Name)
+
+	labels := user.Labels
+	if labels == nil {
+		labels = map[string]string{}
+	}
+	labels["oneblock.ai/creator"] = "oneblock"
+
+	return admission.Patch{admission.PatchOp{
+		Op:    admission.PatchOpReplace,
+		Path:  "/metadata/labels",
+		Value: labels,
+	}}, nil
+}
+
+func (m *mutator) Resource() admission.Resource {
+	return admission.Resource{
+		Names:      []string{"users"},
+		Scope:      admissionregv1.ClusterScope,
+		APIGroup:   managementv1.SchemeGroupVersion.Group,
+		APIVersion: managementv1.SchemeGroupVersion.Version,
+		ObjectType: &managementv1.User{},
+		OperationTypes: []admissionregv1.OperationType{
+			admissionregv1.Create,
+		},
+	}
+}

--- a/pkg/webhook/user/validator.go
+++ b/pkg/webhook/user/validator.go
@@ -1,0 +1,60 @@
+package user
+
+import (
+	"fmt"
+
+	"github.com/oneblock-ai/webhook/pkg/server/admission"
+	"github.com/sirupsen/logrus"
+	admissionregv1 "k8s.io/api/admissionregistration/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	managementv1 "github.com/oneblock-ai/oneblock/pkg/apis/management.oneblock.ai/v1"
+	ctlmanagementv1 "github.com/oneblock-ai/oneblock/pkg/generated/controllers/management.oneblock.ai/v1"
+	"github.com/oneblock-ai/oneblock/pkg/webhook/config"
+)
+
+type validator struct {
+	admission.DefaultValidator
+	userCache ctlmanagementv1.UserCache
+}
+
+var _ admission.Validator = &validator{}
+
+func NewValidator(mgmt *config.Management) admission.Validator {
+	return &validator{
+		userCache: mgmt.OneBlockMgmtFactory.Management().V1().User().Cache(),
+	}
+}
+
+func (v *validator) Create(_ *admission.Request, newObj runtime.Object) error {
+	user := newObj.(*managementv1.User)
+
+	logrus.Infof("[webhook validating]user %s is created", user.Name)
+
+	users, err := v.userCache.List(labels.Everything())
+	if err != nil {
+		return err
+	}
+
+	for _, u := range users {
+		if u.DisplayName == user.DisplayName {
+			return fmt.Errorf("[webhook validating] the display name %s of user %s is already used by user %s", user.DisplayName, user.Name, u.Name)
+		}
+	}
+
+	return nil
+}
+
+func (v *validator) Resource() admission.Resource {
+	return admission.Resource{
+		Names:      []string{"users"},
+		Scope:      admissionregv1.ClusterScope,
+		APIGroup:   managementv1.SchemeGroupVersion.Group,
+		APIVersion: managementv1.SchemeGroupVersion.Version,
+		ObjectType: &managementv1.User{},
+		OperationTypes: []admissionregv1.OperationType{
+			admissionregv1.Create,
+		},
+	}
+}


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->
Integrate webhook server to API server.

**Solution:** 
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
Introduce `oneblock-ai/webhook` repo into API server. 

**Related Issue:**  https://github.com/oneblock-ai/oneblock/issues/8

**Dependency PR**: https://github.com/oneblock-ai/webhook/pull/1

**Test plan:**
<!-- Make sure tests pass on the CI. -->
The PR includes the webhook validator and mutator for the resource `user` as the example.

Apply the below YAML.
```
apiVersion: management.oneblock.ai/v1
displayName: test
isAdmin: true
kind: User
metadata:
  name: test1
password: test1
username: test1
---
apiVersion: management.oneblock.ai/v1
displayName: test
isAdmin: true
kind: User
metadata:
  name: test2
password: test2
username: test2
```
The user `test1` will be created successfully and the webhook mutator will add the lable `oneblock.ai/creator: oneblock` into it.
The creation of the user `test2` is rejected by the webhook validator because it has the same display name as the user `test1`. 
